### PR TITLE
docs: добавить мультиязычный README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# Yaleksandr89.Github.io
+# yaleksandr89.github.io
+
+Публичный сайт: https://yaleksandr89.github.io/
+
+## Выберите язык
+
+| Русский | English | Español | 中文 | Français | Deutsch |
+| --- | --- | --- | --- | --- | --- |
+| **Выбран** | [English](docs/langs/README_en.md) | [Español](docs/langs/README_es.md) | [中文](docs/langs/README_zh.md) | [Français](docs/langs/README_fr.md) | [Deutsch](docs/langs/README_de.md) |
+
+## О проекте
+
+Статическое портфолио PHP Backend / Laravel Developer, опубликованное на GitHub Pages.
+
+Сайт реализован без ручного написания кода, но это не был бесконтрольный автогенерируемый результат: работа велась через постановку задач, review результатов и ручное согласование решений.
+
+## Подход и расширение компетенций
+
+Контекст проекта, ограничения и архитектурные решения фиксировались и согласовывались в ChatGPT Project. AI использовался как инструмент управляемой разработки: решения не принимались автоматически, а проверялись через review и ручное согласование.
+
+### Контролируемый workflow
+
+1. Read-only audit текущего состояния и короткий план.
+2. Согласование решения, границ задачи и списка изменяемых файлов.
+3. Один небольшой implementation step через Codex.
+4. Проверка `git diff`, review результата и только затем согласованная техническая проверка.
+
+### Работа с Codex
+
+- В Ubuntu использовался Codex CLI: `codex-ro` для read-only audit, анализа и review; `codex-rw` — только для согласованных небольших изменений.
+- В Windows применялся Codex app / GUI с тем же разделением: анализ и согласование отдельно, implementation step — после подтверждённого плана.
+- Проверки, требующие Node или Docker, выполнялись пользователем в WSL отдельно от Codex; Open Graph-изображения были подготовлены в ChatGPT.
+
+Этот процесс позволил расширить компетенции работы с ChatGPT Project и AI-assisted workflow, а Astro стал новой технологией в рамках проекта.
+
+## Стек
+
+- `Astro`.
+- `HTML`, `CSS`.
+- `TypeScript`.
+- `GitHub Pages`.
+- `GitHub Actions`.
+
+## Границы проекта
+
+- Статический сайт.
+- Без backend, CMS и database.
+- Без React, Vue, Tailwind и UI libraries.

--- a/docs/langs/README_de.md
+++ b/docs/langs/README_de.md
@@ -1,0 +1,48 @@
+# yaleksandr89.github.io
+
+Public website: https://yaleksandr89.github.io/
+
+## Sprache auswählen
+
+| Русский | English | Español | 中文 | Français | Deutsch |
+| --- | --- | --- | --- | --- | --- |
+| [Русский](../../README.md) | [English](README_en.md) | [Español](README_es.md) | [中文](README_zh.md) | [Français](README_fr.md) | **Ausgewählt** |
+
+## Über das Projekt
+
+Ein statisches Portfolio für einen PHP Backend / Laravel Developer, veröffentlicht auf GitHub Pages.
+
+Die Website wurde ohne manuelles Schreiben von Code umgesetzt, war aber kein unkontrolliert automatisch generiertes Ergebnis: Die Arbeit erfolgte über Aufgabenstellung, Review der Ergebnisse und manuelle Freigabe von Entscheidungen.
+
+## Ansatz und Kompetenzentwicklung
+
+Der Projektkontext, die Einschränkungen und die Architekturentscheidungen wurden in einem ChatGPT Project dokumentiert und abgestimmt. AI wurde als Werkzeug für kontrollierte Entwicklung genutzt: Entscheidungen wurden nicht automatisch übernommen, sondern durch Review und manuelle Freigabe geprüft.
+
+### Kontrollierter Workflow
+
+1. Read-only audit des aktuellen Zustands und ein kurzer Plan.
+2. Freigabe der Lösung, der Aufgabengrenzen und der Liste der zu ändernden Dateien.
+3. Ein kleiner implementation step über Codex.
+4. Prüfung von `git diff`, Review des Ergebnisses und erst danach eine freigegebene technische Prüfung.
+
+### Arbeit mit Codex
+
+- In Ubuntu wurde Codex CLI verwendet: `codex-ro` für read-only audit, Analyse und Review; `codex-rw` nur für freigegebene kleine Änderungen.
+- In Windows wurde Codex app / GUI mit derselben Trennung verwendet: Analyse und Freigabe getrennt, implementation step nach einem bestätigten Plan.
+- Prüfungen, die Node oder Docker erforderten, wurden vom Benutzer separat in WSL außerhalb von Codex ausgeführt; Open Graph images wurden in ChatGPT vorbereitet.
+
+Dieser Prozess half dabei, die Kompetenzen im Umgang mit ChatGPT Project und einem AI-assisted workflow zu erweitern, während Astro eine neue Technologie innerhalb des Projekts wurde.
+
+## Technologie-Stack
+
+- `Astro`.
+- `HTML`, `CSS`.
+- `TypeScript`.
+- `GitHub Pages`.
+- `GitHub Actions`.
+
+## Projektgrenzen
+
+- Statische Website.
+- Kein Backend, kein CMS und keine Datenbank.
+- Kein React, Vue, Tailwind oder UI-Bibliotheken.

--- a/docs/langs/README_en.md
+++ b/docs/langs/README_en.md
@@ -1,0 +1,48 @@
+# yaleksandr89.github.io
+
+Public website: https://yaleksandr89.github.io/
+
+## Choose a language
+
+| Русский | English | Español | 中文 | Français | Deutsch |
+| --- | --- | --- | --- | --- | --- |
+| [Русский](../../README.md) | **Selected** | [Español](README_es.md) | [中文](README_zh.md) | [Français](README_fr.md) | [Deutsch](README_de.md) |
+
+## About the project
+
+A static portfolio for a PHP Backend / Laravel Developer, published on GitHub Pages.
+
+The site was implemented without writing code manually, but it was not an uncontrolled auto-generated result: the work was carried out through task definition, review of results, and manual approval of decisions.
+
+## Approach and competency development
+
+The project context, constraints, and architectural decisions were documented and approved in a ChatGPT Project. AI was used as a controlled development tool: decisions were not accepted automatically, but were checked through review and manual approval.
+
+### Controlled workflow
+
+1. Read-only audit of the current state and a short plan.
+2. Approval of the solution, task boundaries, and list of files to be changed.
+3. One small implementation step through Codex.
+4. Checking `git diff`, reviewing the result, and only then running an approved technical check.
+
+### Working with Codex
+
+- In Ubuntu, Codex CLI was used: `codex-ro` for read-only audit, analysis, and review; `codex-rw` only for approved small changes.
+- In Windows, the Codex app / GUI was used with the same separation: analysis and approval separately, implementation step after a confirmed plan.
+- Checks requiring Node or Docker were performed by the user separately in WSL, outside Codex; Open Graph images were prepared in ChatGPT.
+
+This process helped expand competency in working with ChatGPT Project and an AI-assisted workflow, while Astro became a new technology within the project.
+
+## Technology stack
+
+- `Astro`.
+- `HTML`, `CSS`.
+- `TypeScript`.
+- `GitHub Pages`.
+- `GitHub Actions`.
+
+## Project boundaries
+
+- Static site.
+- No backend, CMS, or database.
+- No React, Vue, Tailwind, or UI libraries.

--- a/docs/langs/README_es.md
+++ b/docs/langs/README_es.md
@@ -1,0 +1,48 @@
+# yaleksandr89.github.io
+
+Public website: https://yaleksandr89.github.io/
+
+## Seleccionar idioma
+
+| Русский | English | Español | 中文 | Français | Deutsch |
+| --- | --- | --- | --- | --- | --- |
+| [Русский](../../README.md) | [English](README_en.md) | **Seleccionado** | [中文](README_zh.md) | [Français](README_fr.md) | [Deutsch](README_de.md) |
+
+## Sobre el proyecto
+
+Un portafolio estático para un PHP Backend / Laravel Developer, publicado en GitHub Pages.
+
+El sitio se implementó sin escribir código manualmente, pero no fue un resultado autogenerado sin control: el trabajo se realizó mediante definición de tareas, review de resultados y aprobación manual de decisiones.
+
+## Enfoque y desarrollo de competencias
+
+El contexto del proyecto, las restricciones y las decisiones arquitectónicas se documentaron y aprobaron en un ChatGPT Project. La AI se utilizó como una herramienta de desarrollo controlado: las decisiones no se aceptaban automáticamente, sino que se verificaban mediante review y aprobación manual.
+
+### Workflow controlado
+
+1. Read-only audit del estado actual y un plan breve.
+2. Aprobación de la solución, los límites de la tarea y la lista de archivos que se iban a modificar.
+3. Un pequeño implementation step mediante Codex.
+4. Revisión de `git diff`, review del resultado y solo después una verificación técnica aprobada.
+
+### Trabajo con Codex
+
+- En Ubuntu se utilizó Codex CLI: `codex-ro` para read-only audit, análisis y review; `codex-rw` solo para pequeños cambios aprobados.
+- En Windows se utilizó Codex app / GUI con la misma separación: análisis y aprobación por separado, implementation step después de un plan confirmado.
+- Las verificaciones que requerían Node o Docker fueron ejecutadas por el usuario por separado en WSL, fuera de Codex; las imágenes Open Graph se prepararon en ChatGPT.
+
+Este proceso ayudó a ampliar las competencias de trabajo con ChatGPT Project y con un AI-assisted workflow, mientras que Astro se convirtió en una tecnología nueva dentro del proyecto.
+
+## Stack tecnológico
+
+- `Astro`.
+- `HTML`, `CSS`.
+- `TypeScript`.
+- `GitHub Pages`.
+- `GitHub Actions`.
+
+## Límites del proyecto
+
+- Sitio estático.
+- Sin backend, CMS ni database.
+- Sin React, Vue, Tailwind ni UI libraries.

--- a/docs/langs/README_fr.md
+++ b/docs/langs/README_fr.md
@@ -1,0 +1,48 @@
+# yaleksandr89.github.io
+
+Public website: https://yaleksandr89.github.io/
+
+## Choisir une langue
+
+| Русский | English | Español | 中文 | Français | Deutsch |
+| --- | --- | --- | --- | --- | --- |
+| [Русский](../../README.md) | [English](README_en.md) | [Español](README_es.md) | [中文](README_zh.md) | **Sélectionné** | [Deutsch](README_de.md) |
+
+## À propos du projet
+
+Un portfolio statique pour un PHP Backend / Laravel Developer, publié sur GitHub Pages.
+
+Le site a été réalisé sans écriture manuelle de code, mais il ne s'agissait pas d'un résultat autogénéré sans contrôle : le travail a été mené par définition des tâches, review des résultats et approbation manuelle des décisions.
+
+## Approche et développement des compétences
+
+Le contexte du projet, les contraintes et les décisions architecturales ont été documentés et approuvés dans un ChatGPT Project. L'AI a été utilisée comme un outil de développement contrôlé : les décisions n'étaient pas acceptées automatiquement, mais vérifiées par review et approbation manuelle.
+
+### Workflow contrôlé
+
+1. Read-only audit de l'état actuel et plan court.
+2. Approbation de la solution, des limites de la tâche et de la liste des fichiers à modifier.
+3. Un petit implementation step via Codex.
+4. Vérification de `git diff`, review du résultat, puis seulement lancement d'une vérification technique approuvée.
+
+### Travailler avec Codex
+
+- Sous Ubuntu, Codex CLI a été utilisé : `codex-ro` pour le read-only audit, l'analyse et la review ; `codex-rw` uniquement pour de petits changements approuvés.
+- Sous Windows, Codex app / GUI a été utilisé avec la même séparation : analyse et approbation séparées, implementation step après un plan confirmé.
+- Les vérifications nécessitant Node ou Docker ont été exécutées séparément par l'utilisateur dans WSL, en dehors de Codex ; les images Open Graph ont été préparées dans ChatGPT.
+
+Ce processus a permis de développer les compétences de travail avec ChatGPT Project et un AI-assisted workflow, tandis qu'Astro est devenu une nouvelle technologie dans le cadre du projet.
+
+## Stack technique
+
+- `Astro`.
+- `HTML`, `CSS`.
+- `TypeScript`.
+- `GitHub Pages`.
+- `GitHub Actions`.
+
+## Limites du projet
+
+- Site statique.
+- Sans backend, CMS ni database.
+- Sans React, Vue, Tailwind ni UI libraries.

--- a/docs/langs/README_zh.md
+++ b/docs/langs/README_zh.md
@@ -1,0 +1,48 @@
+# yaleksandr89.github.io
+
+Public website: https://yaleksandr89.github.io/
+
+## 选择语言
+
+| Русский | English | Español | 中文 | Français | Deutsch |
+| --- | --- | --- | --- | --- | --- |
+| [Русский](../../README.md) | [English](README_en.md) | [Español](README_es.md) | **已选择** | [Français](README_fr.md) | [Deutsch](README_de.md) |
+
+## 关于项目
+
+这是一个 PHP Backend / Laravel Developer 的静态作品集，发布在 GitHub Pages 上。
+
+该网站是在没有手动编写代码的情况下实现的，但这并不是不受控制的自动生成结果：工作通过任务定义、结果 review 和人工确认决策来完成。
+
+## 方法与能力发展
+
+项目上下文、限制条件和架构决策都在 ChatGPT Project 中记录并确认。AI 被用作受控开发工具：决策不会被自动接受，而是通过 review 和人工确认进行检查。
+
+### 受控 workflow
+
+1. 对当前状态进行 read-only audit，并制定简短计划。
+2. 确认解决方案、任务边界以及将要修改的文件列表。
+3. 通过 Codex 完成一个小型 implementation step。
+4. 检查 `git diff`，review 结果，然后才运行已确认的技术检查。
+
+### 使用 Codex
+
+- 在 Ubuntu 中使用 Codex CLI：`codex-ro` 用于 read-only audit、分析和 review；`codex-rw` 仅用于已确认的小型修改。
+- 在 Windows 中使用 Codex app / GUI，并保持相同的分离方式：分析和确认分开进行，implementation step 在计划确认后执行。
+- 需要 Node 或 Docker 的检查由用户在 WSL 中单独执行，不在 Codex 内运行；Open Graph images 在 ChatGPT 中准备。
+
+这个过程帮助扩展了使用 ChatGPT Project 和 AI-assisted workflow 的能力，同时 Astro 也成为本项目中的一项新技术。
+
+## 技术栈
+
+- `Astro`.
+- `HTML`, `CSS`.
+- `TypeScript`.
+- `GitHub Pages`.
+- `GitHub Actions`.
+
+## 项目边界
+
+- 静态网站。
+- 不使用后端、CMS 或数据库。
+- 不使用 React、Vue、Tailwind 或 UI 库。


### PR DESCRIPTION
## Что изменено

- Минимальный корневой README заменён на описание проекта на русском языке.
- Добавлены полные переводы README на английский, испанский, упрощённый китайский, французский и немецкий языки.
- Добавлена навигация между всеми языковыми версиями README.
- Описаны контролируемый AI-assisted workflow, роли ChatGPT Project и Codex, технологический стек и границы проекта.

## Границы изменений

Только документация.

Сайт, исходный код, зависимости, GitHub Actions, маршруты, SEO, public assets, Astro config и TypeScript config не изменялись.